### PR TITLE
Set start and end date

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -86,7 +86,7 @@ func (client *Client) UserInfo(ctx context.Context, token string) (*UserInfo, er
 }
 
 // Sleep requests GET /v1/sleep
-func (client *Client) Sleep(ctx context.Context, token string, dates DatePeriod) (*SleepPeriods, error) {
+func (client *Client) Sleep(ctx context.Context, token string, DatePeriod DatePeriod) (*SleepPeriods, error) {
 	subURL := fmt.Sprintf("/v1/sleep")
 	httpRequest, err := client.newRequest(ctx, "GET", subURL, nil)
 	if err != nil {
@@ -96,8 +96,8 @@ func (client *Client) Sleep(ctx context.Context, token string, dates DatePeriod)
 	httpRequest.Header.Set("Content-Type", "application/json")
 	httpRequest.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	q := httpRequest.URL.Query()
-	q.Add("start", dates.StartDate.String())
-	q.Add("end", dates.EndDate.String())
+	q.Add("start", DatePeriod.StartDate)
+	q.Add("end", DatePeriod.EndDate)
 	httpRequest.URL.RawQuery = q.Encode()
 	httpResponse, err := client.HTTPClient.Do(httpRequest)
 	if err != nil {

--- a/api/client.go
+++ b/api/client.go
@@ -86,7 +86,7 @@ func (client *Client) UserInfo(ctx context.Context, token string) (*UserInfo, er
 }
 
 // Sleep requests GET /v1/sleep
-func (client *Client) Sleep(ctx context.Context, token string, DatePeriod DatePeriod) (*SleepPeriods, error) {
+func (client *Client) Sleep(ctx context.Context, token string, datePeriod DatePeriod) (*SleepPeriods, error) {
 	subURL := fmt.Sprintf("/v1/sleep")
 	httpRequest, err := client.newRequest(ctx, "GET", subURL, nil)
 	if err != nil {
@@ -96,8 +96,8 @@ func (client *Client) Sleep(ctx context.Context, token string, DatePeriod DatePe
 	httpRequest.Header.Set("Content-Type", "application/json")
 	httpRequest.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	q := httpRequest.URL.Query()
-	q.Add("start", DatePeriod.StartDate)
-	q.Add("end", DatePeriod.EndDate)
+	q.Add("start", datePeriod.StartDate)
+	q.Add("end", datePeriod.EndDate)
 	httpRequest.URL.RawQuery = q.Encode()
 	httpResponse, err := client.HTTPClient.Do(httpRequest)
 	if err != nil {
@@ -105,6 +105,34 @@ func (client *Client) Sleep(ctx context.Context, token string, DatePeriod DatePe
 	}
 
 	var apiResponse SleepPeriods
+	log.Printf("HTTP Request: %v", httpResponse.Status)
+	if err := decodeBody(httpResponse, &apiResponse); err != nil {
+		return nil, err
+	}
+
+	return &apiResponse, nil
+}
+
+// Activity requests GET /v1/activity
+func (client *Client) Activity(ctx context.Context, token string, datePeriod DatePeriod) (*Activities, error) {
+	subURL := fmt.Sprintf("/v1/activity")
+	httpRequest, err := client.newRequest(ctx, "GET", subURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	httpRequest.Header.Set("Content-Type", "application/json")
+	httpRequest.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	q := httpRequest.URL.Query()
+	q.Add("start", datePeriod.StartDate)
+	q.Add("end", datePeriod.EndDate)
+	httpRequest.URL.RawQuery = q.Encode()
+	httpResponse, err := client.HTTPClient.Do(httpRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	var apiResponse Activities
 	log.Printf("HTTP Request: %v", httpResponse.Status)
 	if err := decodeBody(httpResponse, &apiResponse); err != nil {
 		return nil, err

--- a/api/schema.go
+++ b/api/schema.go
@@ -1,7 +1,5 @@
 package api
 
-import "time"
-
 // Age represents user age
 type Age int
 
@@ -75,6 +73,6 @@ type Sleep struct {
 
 // DatePeriod struct for required date fields with api request.
 type DatePeriod struct {
-	StartDate time.Time
-	EndDate   time.Time
+	StartDate string
+	EndDate   string
 }

--- a/api/schema.go
+++ b/api/schema.go
@@ -76,3 +76,42 @@ type DatePeriod struct {
 	StartDate string
 	EndDate   string
 }
+
+// Activities represents user activities
+type Activities struct {
+	Activity []Activity `json:"activity"`
+}
+
+// Activity represents user activity
+type Activity struct {
+	SummaryDate            string    `json:"summary_date"`
+	DayStart               string    `json:"day_start"`
+	DayEnd                 string    `json:"day_end"`
+	TimeZone               int       `json:"timezone"`
+	Score                  int       `json:"score"`
+	ScoreStayActive        int       `json:"score_stay_active"`
+	ScoreMoveEveryHour     int       `json:"score_move_every_hour"`
+	ScoreMeetDailyTargets  int       `json:"score_meet_daily_targets"`
+	ScoreTrainingFrequency int       `json:"score_training_frequency"`
+	ScoreTrainingVolume    int       `json:"score_training_volume"`
+	ScoreRecoveryTime      int       `json:"score_recovery_time"`
+	DailyMovement          int       `json:"daily_movement"`
+	NonWear                int       `json:"non_wear"`
+	Rest                   int       `json:"rest"`
+	Inactive               int       `json:"inactive"`
+	InactivityAlerts       int       `json:"inactivity_alerts"`
+	Low                    int       `json:"low"`
+	Medium                 int       `json:"medium"`
+	High                   int       `json:"high"`
+	Steps                  int       `json:"steps"`
+	CalTotal               int       `json:"cal_total"`
+	CalActive              int       `json:"cal_active"`
+	MetMinInactive         int       `json:"met_min_inactive"`
+	MetMinLow              int       `json:"met_min_low"`
+	MetMinMediumPlus       int       `json:"met_min_medium_plus"`
+	MetMinMedium           int       `json:"met_min_medium"`
+	MetMinHigh             int       `json:"met_min_high"`
+	AverageMet             float64   `json:"average_met"`
+	Class5min              string    `json:"class_5min"`
+	Met1min                []float64 `json:"met1min"`
+}

--- a/cmd/activity.go
+++ b/cmd/activity.go
@@ -11,9 +11,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func sleepCommand() *cobra.Command {
+func activityCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "sleeps",
+		Use:   "activities",
 		Short: "fetch sleep",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -27,13 +27,13 @@ func sleepCommand() *cobra.Command {
 			}
 
 			datePeriod := api.DatePeriod{StartDate: startDate, EndDate: endDate}
-			sleeps, err := client.Sleep(ctx, Config.AccessToken, datePeriod)
+			activities, err := client.Activity(ctx, Config.AccessToken, datePeriod)
 			if err != nil {
 				return err
 			}
 
 			var buf bytes.Buffer
-			b, _ := json.Marshal(sleeps)
+			b, _ := json.Marshal(activities)
 			buf.Write(b)
 			fmt.Println(buf.String())
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
@@ -32,7 +33,7 @@ const (
 func NewCommandRoot() *cobra.Command {
 	command := &cobra.Command{
 		Use:           "goura",
-		Short:         "goura is a API client of Oura Cloud",
+		Short:         "goura is an API client of Oura Cloud",
 		Long:          "goura is a Unofficial API client of Oura Cloud written in Go.\nComplete documentation is available at https://github.com/paveg/goura",
 		SilenceErrors: true,
 		SilenceUsage:  true,
@@ -43,6 +44,12 @@ func NewCommandRoot() *cobra.Command {
 	configCommand := configCommand()
 	userInfoCommand := userInfoCommand()
 	sleepCommand := sleepCommand()
+
+	now := time.Now()
+	lastMonth := now.AddDate(0, -1, 0)
+	sleepCommand.Flags().StringVarP(&reqDate.target, "target", "t", "", "wanna get a specific day")
+	sleepCommand.Flags().StringVarP(&reqDate.end, "end", "e", now.Format(dateFormat), "required end date")
+	sleepCommand.Flags().StringVarP(&reqDate.start, "start", "s", lastMonth.Format(dateFormat), "required start date")
 
 	command.AddCommand(versionCommand)
 	command.AddCommand(configCommand)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,16 @@ const (
 	apiBaseURL      string = "https://api.ouraring.com"
 )
 
+type requiredDate struct {
+	start  string
+	end    string
+	target string
+}
+
+var reqDate = &requiredDate{}
+
+const dateFormat = "2006-01-02"
+
 // NewCommandRoot initializes a root command function.
 func NewCommandRoot() *cobra.Command {
 	command := &cobra.Command{
@@ -44,17 +54,22 @@ func NewCommandRoot() *cobra.Command {
 	configCommand := configCommand()
 	userInfoCommand := userInfoCommand()
 	sleepCommand := sleepCommand()
+	activityCommand := activityCommand()
 
 	now := time.Now()
 	lastMonth := now.AddDate(0, -1, 0)
-	sleepCommand.Flags().StringVarP(&reqDate.target, "target", "t", "", "wanna get a specific day")
-	sleepCommand.Flags().StringVarP(&reqDate.end, "end", "e", now.Format(dateFormat), "required end date")
-	sleepCommand.Flags().StringVarP(&reqDate.start, "start", "s", lastMonth.Format(dateFormat), "required start date")
+	commands := []*cobra.Command{sleepCommand, activityCommand}
+	for _, cmd := range commands {
+		cmd.Flags().StringVarP(&reqDate.target, "target", "t", "", "wanna get a specific day")
+		cmd.Flags().StringVarP(&reqDate.end, "end", "e", now.Format(dateFormat), "required end date")
+		cmd.Flags().StringVarP(&reqDate.start, "start", "s", lastMonth.Format(dateFormat), "required start date")
+	}
 
 	command.AddCommand(versionCommand)
 	command.AddCommand(configCommand)
 	command.AddCommand(userInfoCommand)
 	command.AddCommand(sleepCommand)
+	command.AddCommand(activityCommand)
 	return command
 }
 
@@ -104,4 +119,22 @@ func createConfigFile(filePath string) {
 		os.Exit(failedExecution)
 	}
 	defer file.Close()
+}
+
+func initDate() (string, string, error) {
+	if reqDate.target != "" {
+		reqDate.start = reqDate.target
+		reqDate.end = reqDate.target
+	}
+
+	startDate, err := time.Parse(dateFormat, reqDate.start)
+	if err != nil {
+		return "", "", err
+	}
+	endDate, err := time.Parse(dateFormat, reqDate.end)
+	if err != nil {
+		return "", "", err
+	}
+
+	return startDate.Format(dateFormat), endDate.Format(dateFormat), err
 }

--- a/cmd/sleep.go
+++ b/cmd/sleep.go
@@ -12,6 +12,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type requiredDate struct {
+	start  string
+	end    string
+	target string
+}
+
+var reqDate = &requiredDate{}
+
+const dateFormat = "2006-01-02"
+
 func sleepCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sleeps",
@@ -22,17 +32,13 @@ func sleepCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			format := "2006-01-02"
-			start, err := time.Parse(format, "2019-08-01")
+			startDate, endDate, err := initDate()
 			if err != nil {
 				return err
 			}
-			end, err := time.Parse(format, "2019-09-01")
-			if err != nil {
-				return err
-			}
-			dp := api.DatePeriod{StartDate: start, EndDate: end}
-			resp, err := client.Sleep(ctx, Config.AccessToken, dp)
+
+			datePeriod := api.DatePeriod{StartDate: startDate, EndDate: endDate}
+			resp, err := client.Sleep(ctx, Config.AccessToken, datePeriod)
 			if err != nil {
 				return err
 			}
@@ -47,4 +53,22 @@ func sleepCommand() *cobra.Command {
 	}
 
 	return cmd
+}
+
+func initDate() (string, string, error) {
+	if reqDate.target != "" {
+		reqDate.start = reqDate.target
+		reqDate.end = reqDate.target
+	}
+
+	startDate, err := time.Parse(dateFormat, reqDate.start)
+	if err != nil {
+		return "", "", err
+	}
+	endDate, err := time.Parse(dateFormat, reqDate.end)
+	if err != nil {
+		return "", "", err
+	}
+
+	return startDate.Format(dateFormat), endDate.Format(dateFormat), err
 }


### PR DESCRIPTION
## :sparkles: Feature
- Describe features.
  - set your date

### help
```bash
$ goura sleeps -h
fetch sleep

Usage:
  goura sleeps [flags]

Flags:
  -e, --end string      required end date (default "2019-09-07")
  -h, --help            help for sleeps
  -s, --start string    required start date (default "2019-08-07")
  -t, --target string   wanna get a specific day
```

### set your date

<details>
<summary>use --start and --end</summary>

```bash
$ goura sleeps --start 2019-02-01 --end 2019-02-02 | jq .
2019/09/07 09:18:44 HTTP Request: 200 OK
{
  "sleep": [
    {
      "summary_date": "2019-02-01",
      "period_id": 0,
      "is_longest": 1,
      "time_zone": 0,
      "bedtime_start": "2019-02-02T06:02:32+09:00",
      "bedtime_end": "2019-02-02T12:52:32+09:00",
      "score": 55,
      "score_total": 50,
      "score_disturbances": 68,
      "score_efficiency": 69,
      "score_latency": 88,
      "score_rem": 64,
      "score_deep": 48,
      "score_alignment": 1,
      "total": 19500,
      "duration": 24600,
      "awake": 5100,
      "light": 11940,
      "rem": 4710,
      "deep": 2850,
      "onset_latency": 480,
      "restless": 50,
      "efficiency": 79,
      "midpoint_time": 11040,
      "hr_lowest": 52,
      "hr_average": 59.875,
      "rmssd": 65,
      "breath_average": 15.5,
      "temperature_delta": -0.14,
      "hypnogram_5min": "4422222211111112442222224233332233222222222212223333333222222222223342444444444444"
    },
    {
      "summary_date": "2019-02-02",
      "period_id": 0,
      "is_longest": 1,
      "time_zone": 0,
      "bedtime_start": "2019-02-03T00:47:28+09:00",
      "bedtime_end": "2019-02-03T09:37:28+09:00",
      "score": 72,
      "score_total": 79,
      "score_disturbances": 64,
      "score_efficiency": 83,
      "score_latency": 85,
      "score_rem": 96,
      "score_deep": 48,
      "score_alignment": 34,
      "total": 27000,
      "duration": 31800,
      "awake": 4800,
      "light": 16590,
      "rem": 7560,
      "deep": 2850,
      "onset_latency": 1440,
      "restless": 44,
      "efficiency": 85,
      "midpoint_time": 15840,
      "hr_lowest": 52,
      "hr_average": 63.75,
      "rmssd": 56,
      "breath_average": 16.25,
      "temperature_delta": -0.18,
      "hypnogram_5min": "4444422222222211222221121222111122233322222222233444433222222222222222333322222232222223333333333333444344"
    }
  ]
}
```

</details>

<details>
<summary>use --target</summary>

```bash
$ goura sleeps --target 2019-03-01 | jq .
2019/09/07 09:22:44 HTTP Request: 200 OK
{
  "sleep": [
    {
      "summary_date": "2019-03-01",
      "period_id": 0,
      "is_longest": 1,
      "time_zone": 0,
      "bedtime_start": "2019-03-02T00:57:59+09:00",
      "bedtime_end": "2019-03-02T07:46:59+09:00",
      "score": 53,
      "score_total": 43,
      "score_disturbances": 55,
      "score_efficiency": 53,
      "score_latency": 81,
      "score_rem": 43,
      "score_deep": 49,
      "score_alignment": 68,
      "total": 17670,
      "duration": 24540,
      "awake": 6870,
      "light": 11550,
      "rem": 3180,
      "deep": 2940,
      "onset_latency": 180,
      "restless": 42,
      "efficiency": 72,
      "midpoint_time": 11160,
      "hr_lowest": 51,
      "hr_average": 60.625,
      "rmssd": 50,
      "breath_average": 14.75,
      "temperature_delta": 0.05,
      "hypnogram_5min": "4222444444222222122111221123344333322222222212221234222222144332334222244244444444"
    }
  ]
}
```

</details>

## :link: References
- Attach any referenced pages.
  - url

